### PR TITLE
Forcibly disable sidebar caching

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -3,10 +3,15 @@
   "author": "Jlerner, MyWikis LLC",
   "url": "https://github.com/mywikis/EmailLogger",
   "description": "Hides sidebar from anonymous users",
-  "version": "2.1",
+  "version": "2.1.1",
   "license-name": "GPL-2.0",
   "type": "other",
   "manifest_version": 1,
+  "config": {
+    "EnableSidebarCache": {
+      "value": false
+    }
+  },
   "Hooks": {
     "SkinBuildSidebar": "HideSidebarHooks::efHideSidebar"
   },


### PR DESCRIPTION
When `$wgEnableSidebarCache` is enabled, this extension doesn't function properly. (Specifically, upon login or logout, the wrong version of the sidebar may show up.) This will set it to false.