### PR TITLE
Fix compatibility with 1.38

### DIFF
--- a/HideSidebar.hooks.php
+++ b/HideSidebar.hooks.php
@@ -1,9 +1,8 @@
 <?php
 class HideSidebarHooks {
     public static function efHideSidebar( $skin, &$bar ) {
-        global $wgUser;
         // Hide sidebar for anonymous users
-        if ( !$wgUser->isLoggedIn() ) {
+        if ( $skin->getUser()->isAnon() ) {
             $url = Title::makeTitle( NS_SPECIAL, 'UserLogin' )->getLocalUrl();
             $bar = [];
             $bar['navigation'][] = [


### PR DESCRIPTION
1. User::isLoggedIn() is removed: use User::isAnon()
2. The global $wgUser should be avoided and the context is available here.

This commit is compatible with MW 1.18+:
* Skin extends ContextSource since 1.18,
* ContextSource::getUser() exists since 1.18,
* User::isAnon() exists since 1.5.

Resolves #4